### PR TITLE
chore: drop Tailwind, replace with plain CSS

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -14,6 +14,5 @@
 	"singleQuote": false,
 	"tabWidth": 4,
 	"trailingComma": "es5",
-	"useTabs": true,
-	"plugins": ["prettier-plugin-tailwindcss"]
+	"useTabs": true
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,24 +5,24 @@ Single-page landing site for [jedwards.cc](https://jedwards.cc) — pure SPA, no
 ## Stack
 
 - Vite 8 + React 19 + TypeScript 6
-- Tailwind CSS v4 (CSS-first config in `src/index.css`)
+- Plain CSS (no framework) — variables + media query for light/dark in `src/index.css`
 - Bun for installs (`bun.lock`, text format since Bun 1.2)
 - Plausible analytics via plain `<script>` tag in `index.html`
 - Cloudflare Pages hosting (V3 build image required — V2 is pinned to Node 18)
 
 ## Commands
 
-| Command | Description |
-|---|---|
-| `bun install --frozen-lockfile` | Install deps |
-| `bun run dev` | Vite dev server on http://localhost:3000 |
-| `bun run build` | `tsc -b` + Vite production build to `dist/` |
-| `bun run preview` | Serve built `dist/` on http://localhost:4173 |
-| `bun run lint` | ESLint (flat config) |
-| `bun run typecheck` | `tsc -b --noEmit` |
-| `bun run format` | Prettier with Tailwind class sorting |
-| `bun run test:e2e` | Playwright smoke tests |
-| `bun run deploy` | Build + manual deploy via `wrangler pages deploy dist` |
+| Command                         | Description                                            |
+| ------------------------------- | ------------------------------------------------------ |
+| `bun install --frozen-lockfile` | Install deps                                           |
+| `bun run dev`                   | Vite dev server on http://localhost:3000               |
+| `bun run build`                 | `tsc -b` + Vite production build to `dist/`            |
+| `bun run preview`               | Serve built `dist/` on http://localhost:4173           |
+| `bun run lint`                  | ESLint (flat config)                                   |
+| `bun run typecheck`             | `tsc -b --noEmit`                                      |
+| `bun run format`                | Prettier (tabs, width 4)                               |
+| `bun run test:e2e`              | Playwright smoke tests                                 |
+| `bun run deploy`                | Build + manual deploy via `wrangler pages deploy dist` |
 
 ## Layout
 
@@ -31,7 +31,7 @@ Single-page landing site for [jedwards.cc](https://jedwards.cc) — pure SPA, no
 ├── src/
 │   ├── App.tsx        # the homepage (everything renders here)
 │   ├── main.tsx       # React entry
-│   └── index.css      # Tailwind v4 directives + CSS-first config
+│   └── index.css      # Plain CSS (variables + prefers-color-scheme)
 ├── public/            # static assets (resume PDF, screenshots)
 │   └── 404.html       # CF Pages 404 fallback
 ├── tests/
@@ -58,4 +58,4 @@ job, on every PR. Both jobs must be green before merging.
 
 - **Indentation**: tabs (see `.prettierrc` — `useTabs: true`, `tabWidth: 4`)
 - **Linting**: ESLint flat config (`eslint.config.js`)
-- **Class sorting**: `prettier-plugin-tailwindcss` — run `bun run format` before committing
+- **Formatting**: run `bun run format` before committing

--- a/README.md
+++ b/README.md
@@ -5,22 +5,22 @@ Single-page landing site for [jedwards.cc](https://jedwards.cc).
 ## Stack
 
 - [Vite](https://vite.dev/) + [React 19](https://react.dev/) + [TypeScript](https://www.typescriptlang.org/)
-- [Tailwind CSS v4](https://tailwindcss.com/) (CSS-first config)
+- Plain CSS — light/dark via `prefers-color-scheme`
 - [Plausible](https://plausible.io/) analytics (no JS package, just a `<script>` tag)
 - [Cloudflare Pages](https://pages.cloudflare.com/) hosting
 
 ## Scripts
 
-| Command | What it does |
-|---|---|
-| `bun run dev` | Vite dev server on http://localhost:3000 |
-| `bun run build` | Type-check + production build to `dist/` |
-| `bun run preview` | Serve the built `dist/` on http://localhost:4173 |
-| `bun run lint` | ESLint (flat config) |
-| `bun run typecheck` | `tsc -b --noEmit` |
-| `bun run format` | Prettier (with Tailwind class sorting) |
-| `bun run test:e2e` | Playwright smoke tests |
-| `bun run deploy` | Build + `wrangler pages deploy dist` |
+| Command             | What it does                                     |
+| ------------------- | ------------------------------------------------ |
+| `bun run dev`       | Vite dev server on http://localhost:3000         |
+| `bun run build`     | Type-check + production build to `dist/`         |
+| `bun run preview`   | Serve the built `dist/` on http://localhost:4173 |
+| `bun run lint`      | ESLint (flat config)                             |
+| `bun run typecheck` | `tsc -b --noEmit`                                |
+| `bun run format`    | Prettier (tabs, width 4)                         |
+| `bun run test:e2e`  | Playwright smoke tests                           |
+| `bun run deploy`    | Build + `wrangler pages deploy dist`             |
 
 ## Cloudflare Pages
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,6 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",
-        "@tailwindcss/vite": "^4.3.0",
         "@types/node": "^24.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -19,8 +18,6 @@
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.6.0",
         "prettier": "^3.8.3",
-        "prettier-plugin-tailwindcss": "^0.8.0",
-        "tailwindcss": "^4.3.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.3",
         "vite": "^8.0.13",
@@ -267,36 +264,6 @@
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.15", "", {}, "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw=="],
 
-    "@tailwindcss/node": ["@tailwindcss/node@4.3.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.21.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.0" } }, "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g=="],
-
-    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.0", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.0", "@tailwindcss/oxide-darwin-arm64": "4.3.0", "@tailwindcss/oxide-darwin-x64": "4.3.0", "@tailwindcss/oxide-freebsd-x64": "4.3.0", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0", "@tailwindcss/oxide-linux-arm64-musl": "4.3.0", "@tailwindcss/oxide-linux-x64-gnu": "4.3.0", "@tailwindcss/oxide-linux-x64-musl": "4.3.0", "@tailwindcss/oxide-wasm32-wasi": "4.3.0", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0", "@tailwindcss/oxide-win32-x64-msvc": "4.3.0" } }, "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg=="],
-
-    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.3.0", "", { "os": "android", "cpu": "arm64" }, "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng=="],
-
-    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.3.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ=="],
-
-    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.3.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA=="],
-
-    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.3.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ=="],
-
-    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0", "", { "os": "linux", "cpu": "arm" }, "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA=="],
-
-    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg=="],
-
-    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ=="],
-
-    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ=="],
-
-    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg=="],
-
-    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.3.0", "", { "dependencies": { "@emnapi/core": "^1.10.0", "@emnapi/runtime": "^1.10.0", "@emnapi/wasi-threads": "^1.2.1", "@napi-rs/wasm-runtime": "^1.1.4", "@tybys/wasm-util": "^0.10.1", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA=="],
-
-    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ=="],
-
-    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA=="],
-
-    "@tailwindcss/vite": ["@tailwindcss/vite@4.3.0", "", { "dependencies": { "@tailwindcss/node": "4.3.0", "@tailwindcss/oxide": "4.3.0", "tailwindcss": "4.3.0" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw=="],
-
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
     "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
@@ -367,8 +334,6 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.356", "", {}, "sha512-9NgFd7m5t5MCJ5rUSjJITUXAH9mEGlrlofnMf4YEr+pz6JlP7cWmTAH+JFmbPnaSW8koVTkuW7pacORWAnA5Yw=="],
 
-    "enhanced-resolve": ["enhanced-resolve@5.21.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q=="],
-
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
     "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
@@ -420,8 +385,6 @@
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
     "globals": ["globals@17.6.0", "", {}, "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA=="],
-
-    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
 
@@ -485,8 +448,6 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
-    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
-
     "miniflare": ["miniflare@4.20260515.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260515.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-2j0oQWizk1Eu4Cm8tDX7Z+Nsjd0nebIj1TQcQ+Oy1QKeo0Ay9+bdn8wfLAtOj9znDCybDCUlnS1+nYvKXEdfNg=="],
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
@@ -527,8 +488,6 @@
 
     "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
-    "prettier-plugin-tailwindcss": ["prettier-plugin-tailwindcss@0.8.0", "", { "peerDependencies": { "@ianvs/prettier-plugin-sort-imports": "*", "@prettier/plugin-hermes": "*", "@prettier/plugin-oxc": "*", "@prettier/plugin-pug": "*", "@shopify/prettier-plugin-liquid": "*", "@trivago/prettier-plugin-sort-imports": "*", "@zackad/prettier-plugin-twig": "*", "prettier": "^3.0", "prettier-plugin-astro": "*", "prettier-plugin-css-order": "*", "prettier-plugin-jsdoc": "*", "prettier-plugin-marko": "*", "prettier-plugin-multiline-arrays": "*", "prettier-plugin-organize-attributes": "*", "prettier-plugin-organize-imports": "*", "prettier-plugin-sort-imports": "*", "prettier-plugin-svelte": "*" }, "optionalPeers": ["@ianvs/prettier-plugin-sort-imports", "@prettier/plugin-hermes", "@prettier/plugin-oxc", "@prettier/plugin-pug", "@shopify/prettier-plugin-liquid", "@trivago/prettier-plugin-sort-imports", "@zackad/prettier-plugin-twig", "prettier-plugin-astro", "prettier-plugin-css-order", "prettier-plugin-jsdoc", "prettier-plugin-marko", "prettier-plugin-multiline-arrays", "prettier-plugin-organize-attributes", "prettier-plugin-organize-imports", "prettier-plugin-sort-imports", "prettier-plugin-svelte"] }, "sha512-V8ITGH87yuBDF6JpEZTOVlUz/saAwqb8f3HRgUj8Lh+tGCcrmorhsLpYqzygwFwK0PE2Ib6Mv3M7T/uE2tZV1g=="],
-
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
@@ -550,10 +509,6 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
-
-    "tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
-
-    "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
@@ -604,18 +559,6 @@
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
-
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
-
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
-
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
-
-    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" }, "bundled": true }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
-
-    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
-
-    "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 

--- a/index.html
+++ b/index.html
@@ -7,11 +7,7 @@
 		<title>J. Edwards</title>
 		<meta
 			name="description"
-			content="Discover the professional world of Justin Edwards, a Full Stack Developer based in Clearwater, FL. Explore my portfolio featuring projects in NextJS, TypeScript, SQL, and AWS, and connect with me on LinkedIn and GitHub."
-		/>
-		<meta
-			name="keywords"
-			content="Justin Edwards, Full Stack Developer, Software Engineer, NextJS, TypeScript, SQL, AWS, Portfolio, Clearwater, Florida"
+			content="Justin Edwards — Platform Engineer."
 		/>
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -25,7 +21,7 @@
 			src="https://plausible.io/js/script.outbound-links.file-downloads.js"
 		></script>
 	</head>
-	<body class="font-sans">
+	<body>
 		<div id="root"></div>
 		<script type="module" src="/src/main.tsx"></script>
 	</body>

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.60.0",
-		"@tailwindcss/vite": "^4.3.0",
 		"@types/node": "^24.0.0",
 		"@types/react": "^19.0.0",
 		"@types/react-dom": "^19.0.0",
@@ -29,8 +28,6 @@
 		"eslint-plugin-react-refresh": "^0.5.2",
 		"globals": "^17.6.0",
 		"prettier": "^3.8.3",
-		"prettier-plugin-tailwindcss": "^0.8.0",
-		"tailwindcss": "^4.3.0",
 		"typescript": "^6.0.3",
 		"typescript-eslint": "^8.59.3",
 		"vite": "^8.0.13",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,12 @@
 export default function App() {
 	return (
-		<main className="flex min-h-screen flex-col items-center justify-center p-4 text-center sm:p-12 md:p-24">
-			<p className="text-4xl transition-all md:text-5xl">
-				Justin Edwards
-			</p>
-			<p className="text-xl font-semibold transition-all md:text-2xl">
-				Platform Engineer
-			</p>
-			<p className="text-neutral-400 transition-colors hover:text-blue-400">
-				<a href="mailto:justin@jedwards.cc">justin@jedwards.cc</a>
+		<main className="page">
+			<p className="name">Justin Edwards</p>
+			<p className="role">Platform Engineer</p>
+			<p className="email-wrap">
+				<a className="email" href="mailto:justin@jedwards.cc">
+					justin@jedwards.cc
+				</a>
 			</p>
 		</main>
 	);

--- a/src/index.css
+++ b/src/index.css
@@ -1,31 +1,103 @@
-@import "tailwindcss";
-
-@theme {
-	--font-sans:
-		"Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
-		"Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji";
-}
-
 :root {
-	--foreground-rgb: 0, 0, 0;
-	--background-start-rgb: 214, 219, 220;
-	--background-end-rgb: 255, 255, 255;
+	color-scheme: light dark;
+	--bg: #ffffff;
+	--fg: #0a0a0a;
+	--muted: #525252;
+	--link-hover: #1d4ed8;
 }
 
 @media (prefers-color-scheme: dark) {
 	:root {
-		--foreground-rgb: 255, 255, 255;
-		--background-start-rgb: 0, 0, 0;
-		--background-end-rgb: 0, 0, 0;
+		--bg: #0a0a0a;
+		--fg: #fafafa;
+		--muted: #a3a3a3;
+		--link-hover: #60a5fa;
 	}
 }
 
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+}
+
+html,
 body {
-	color: rgb(var(--foreground-rgb));
-	background: linear-gradient(
-			to bottom,
-			transparent,
-			rgb(var(--background-end-rgb))
-		)
-		rgb(var(--background-start-rgb));
+	margin: 0;
+	padding: 0;
+}
+
+body {
+	font-family:
+		"Inter",
+		ui-sans-serif,
+		system-ui,
+		-apple-system,
+		"Segoe UI",
+		Roboto,
+		"Helvetica Neue",
+		Arial,
+		"Apple Color Emoji",
+		"Segoe UI Emoji";
+	background: var(--bg);
+	color: var(--fg);
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+.page {
+	display: flex;
+	min-height: 100vh;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	padding: 1rem;
+	text-align: center;
+}
+
+@media (min-width: 640px) {
+	.page {
+		padding: 3rem;
+	}
+}
+
+@media (min-width: 768px) {
+	.page {
+		padding: 6rem;
+	}
+}
+
+.name {
+	margin: 0;
+	font-size: 2.25rem;
+}
+
+.role {
+	margin: 0;
+	font-size: 1.25rem;
+	font-weight: 600;
+}
+
+@media (min-width: 768px) {
+	.name {
+		font-size: 3rem;
+	}
+	.role {
+		font-size: 1.5rem;
+	}
+}
+
+.email-wrap {
+	margin: 0;
+}
+
+.email {
+	color: var(--muted);
+	text-decoration: none;
+	transition: color 150ms;
+}
+
+.email:hover,
+.email:focus-visible {
+	color: var(--link-hover);
 }

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -20,13 +20,6 @@ test.describe("homepage", () => {
 			"mailto:justin@jedwards.cc"
 		);
 
-		// Hover state: parent <p> should have hover:text-blue-400. We confirm
-		// the baseline neutral-400 class is present and that hover doesn't
-		// throw — full color assertion is brittle across browsers.
-		const linkParent = email.locator("xpath=..");
-		await expect(linkParent).toHaveClass(/text-neutral-400/);
-		await expect(linkParent).toHaveClass(/hover:text-blue-400/);
-
 		expect(consoleErrors).toEqual([]);
 	});
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,9 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import tailwindcss from "@tailwindcss/vite";
 
 // https://vite.dev/config/
 export default defineConfig({
-	plugins: [react(), tailwindcss()],
+	plugins: [react()],
 	server: {
 		port: 3000,
 		strictPort: true,


### PR DESCRIPTION
## Summary

Tailwind v4 was overkill for a 3-line landing page. Swapping it for plain CSS, fixing the email contrast that was failing WCAG AA, and tightening the meta tags.

## Before / after

| Metric | Before | After | Δ |
|---|---|---|---|
| CSS bundle | 6.75 kB | 1.11 kB | **−84%** |
| CSS gzipped | 2.19 kB | 0.57 kB | −74% |
| HTML | 1.27 kB | 0.91 kB | −28% |
| JS bundle | 190.93 kB | 190.74 kB | ~0 (all React) |
| `node_modules` | 331M / 7611 files | 320M / 7401 files | −11M / −210 files |
| Devdeps removed | — | `tailwindcss`, `@tailwindcss/vite`, `prettier-plugin-tailwindcss` | 3 |

## Visual

Same shape as before. Two intentional design changes:

1. **Gradient backgrounds gone.** Light gradient (`#d6dbdc → white`) was so faint it just read as off-white; dark was harsh pure black. Now flat `#ffffff` / `#0a0a0a`.
2. **Email contrast fixed.** Was `text-neutral-400` (`#a3a3a3`) on white = **2.5:1** (fails WCAG AA). Now `#525252` on white = **7.5:1** (passes AAA). Dark mode kept the lighter `#a3a3a3` on `#0a0a0a` (already passing).

## Other changes

- `<meta description>` updated to `"Justin Edwards — Platform Engineer."` (was stale "Full Stack Developer based in Clearwater, FL" with NextJS/SQL/AWS keywords).
- `<meta keywords>` removed (Google ignores it).
- Smoke test no longer asserts Tailwind class names on the email parent — those were testing implementation, not behavior. Visibility + `href` assertions remain.
- CLAUDE.md / README updated to reflect plain-CSS stack.

## Test plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run test:e2e` (2 passed)
- [x] Visual check: light + dark + mobile in Playwright
- [x] Confirmed email link computed color = `rgb(82,82,82)` over white bg (7.5:1)