### PR TITLE
ci: add Claude PR review (review-team) via shared reusable workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
   pull-requests: write
   id-token: write
 

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -8,6 +8,11 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
 
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
 jobs:
   review:
     uses: jedwards1230/release-workflows/.github/workflows/claude-pr-review.yml@v1

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,25 @@
+# Claude PR review — calls the shared reusable workflow in
+# jedwards1230/release-workflows, which runs claude-code-action@v1 in Haiku
+# PR-review mode with the public jedwards1230-plugins marketplace + review-team
+# plugin enabled by default. The focus below is appended to the base prompt.
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  review:
+    uses: jedwards1230/release-workflows/.github/workflows/claude-pr-review.yml@v1
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    with:
+      focus: |
+        personal-website is a web frontend (jedwards.cc).
+        - XSS: unescaped user/dynamic content, dangerouslySetInnerHTML / v-html
+          / raw template interpolation.
+        - Secrets: no API keys or tokens leaking into the client bundle / public
+          env vars.
+        - Build/config correctness; broken links or routes introduced by the
+          change.
+        Do NOT re-flag eslint/prettier/formatting — CI owns those.


### PR DESCRIPTION
Adds a thin caller for the shared reusable PR-review workflow `jedwards1230/release-workflows/.github/workflows/claude-pr-review.yml@v1`, which runs claude-code-action@v1 (Haiku) with the public jedwards1230-plugins marketplace + review-team plugin enabled by default, plus a personal-website-specific focus. Requires the `ANTHROPIC_API_KEY` repo secret.