### PR TITLE
docs: minor documentation cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ Single-page landing site for [jedwards.cc](https://jedwards.cc) — pure SPA, no
 - Plain CSS (no framework) — variables + media query for light/dark in `src/index.css`
 - Bun for installs (`bun.lock`, text format since Bun 1.2)
 - Plausible analytics via plain `<script>` tag in `index.html`
+- Inter font loaded from Google Fonts (`index.html`)
 - Cloudflare Pages hosting (V3 build image required — V2 is pinned to Node 18)
 
 ## Commands
@@ -32,7 +33,7 @@ Single-page landing site for [jedwards.cc](https://jedwards.cc) — pure SPA, no
 │   ├── App.tsx        # the homepage (everything renders here)
 │   ├── main.tsx       # React entry
 │   └── index.css      # Plain CSS (variables + prefers-color-scheme)
-├── public/            # static assets (resume PDF, screenshots)
+├── public/            # static assets (resume PDF, favicon, portfolio preview images)
 │   └── 404.html       # CF Pages 404 fallback
 ├── tests/
 │   └── smoke.spec.ts  # Playwright smoke
@@ -51,8 +52,8 @@ provisioned in [lilbro-tf](https://github.com/jedwards1230/lilbro-tf) at
 
 ## CI
 
-`.github/workflows/ci.yml` runs lint → typecheck → build, then a Playwright e2e
-job, on every PR. Both jobs must be green before merging.
+`.github/workflows/ci.yml` runs lint, typecheck, build, and Playwright e2e on every
+PR (both jobs install and build independently). Both must be green before merging.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ Single-page landing site for [jedwards.cc](https://jedwards.cc).
 | `bun run test:e2e`  | Playwright smoke tests                           |
 | `bun run deploy`    | Build + `wrangler pages deploy dist`             |
 
-## Cloudflare Pages
+## Deploy
 
-`wrangler.toml` points at `dist/`. The dashboard build command should be `bun run build`. Framework preset: **None** (or "Vite"). Output directory: `dist`.
+Auto-deploys on push to `main` via Cloudflare Pages. The Pages project is provisioned
+via Terraform — see [CLAUDE.md](./CLAUDE.md) for build image requirements and the
+Terraform module location.
 
 The static `public/404.html` is served automatically on unmatched routes.


### PR DESCRIPTION
## Summary

- **CLAUDE.md** — `public/` comment updated from `(resume PDF, screenshots)` to `(resume PDF, favicon, portfolio preview images)` to reflect actual directory contents (favicon.ico + named portfolio preview PNGs were not mentioned)
- **CLAUDE.md** — Stack section: added one-line note that Inter is loaded from Google Fonts (`index.html`)
- **CLAUDE.md** — CI description reworded to clarify that the `e2e` job runs `bun install` + `bun run build` independently (it does not consume the artifact uploaded by the `build` job); the old phrasing "lint → typecheck → build, then a Playwright e2e job" implied artifact chaining that isn't happening
- **README.md** — Replaced the stale "Cloudflare Pages" section (which told readers to edit the dashboard build command) with a brief "Deploy" pointer to CLAUDE.md and the Terraform source of truth; that section contradicted CLAUDE.md's explicit note to change settings in lilbro-tf, not the dashboard

## Already correct / not changed

- CLAUDE.md Deploy section already correctly references lilbro-tf as the source of truth — no change needed there

## Follow-up (not in this PR)

- `wrangler.toml` is mostly commented-out Wrangler boilerplate (smart placement, AI, D1, Durable Objects, KV, queues, R2, service bindings, preview/production env stubs) — none of these bindings are in use for this pure-static SPA. Worth trimming to just the active `name`, `compatibility_date`, and `pages_build_output_dir` lines in a future cleanup PR.