### PR TITLE
Add Playwright visual verification setup

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# SessionStart hook: provision the browsers this repo needs.
+#
+# Two consumers need browser binaries, and a fresh container ships without them:
+#   - firefox: the Playwright MCP server declared in .mcp.json (`--browser firefox`)
+#     used for interactive visual verification. Without it the first
+#     browser_navigate call fails with "Browser firefox is not installed".
+#   - chromium: the automated `test:e2e` suite (playwright.config.ts pins the
+#     `chromium` project). Without it `bun run test:e2e` fails on web.
+#
+# Scoped to Claude Code on the web (remote) sessions; local machines are assumed
+# to manage their own Playwright install. Safe to re-run: every command is
+# idempotent and the downloaded browsers are cached in the container image.
+set -euo pipefail
+
+# Only provision in the remote (web) environment.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Keep the browsers in the well-known cache the container persists.
+export PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_BROWSERS_PATH:-/opt/pw-browsers}"
+
+echo "[session-start] installing Playwright OS deps + browsers (firefox, chromium)..."
+
+# OS-level shared libraries the browsers need (apt; requires root).
+npx -y playwright@latest install-deps firefox chromium
+
+# firefox: keep its build in lockstep with the @playwright/mcp server we run.
+npx -y @playwright/mcp@latest install-browser firefox
+
+# chromium: the browser the automated test:e2e suite (playwright.config.ts) uses.
+npx -y playwright@latest install chromium
+
+echo "[session-start] Playwright firefox + chromium ready."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,47 @@
+{
+	"$schema": "https://json.schemastore.org/claude-code-settings.json",
+	"permissions": {
+		"allow": [
+			"Edit",
+			"Write",
+			"Bash(bun install:*)",
+			"Bash(bun run:*)",
+			"Bash(bunx:*)",
+			"Bash(npx playwright:*)",
+			"Bash(git add:*)",
+			"Bash(git commit:*)",
+			"Bash(git push:*)",
+			"Bash(git log:*)",
+			"Bash(git diff:*)",
+			"Bash(git status:*)",
+			"Bash(git checkout:*)",
+			"Bash(git branch:*)",
+			"Bash(gh pr create:*)",
+			"Bash(gh pr view:*)",
+			"Bash(gh pr list:*)",
+			"Bash(gh pr checks:*)",
+			"Bash(gh run view:*)",
+			"Bash(ls:*)",
+			"Bash(grep:*)",
+			"Bash(rg:*)",
+			"Bash(curl:*)",
+			"Bash(tree:*)",
+			"Bash(wc:*)",
+			"WebFetch",
+			"WebSearch",
+			"Skill"
+		]
+	},
+	"hooks": {
+		"SessionStart": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+					}
+				]
+			}
+		]
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /coverage
 /test-results
 /playwright-report
+.playwright-mcp/
 
 # build
 /dist
@@ -20,6 +21,9 @@
 # misc
 .DS_Store
 *.pem
+
+# claude code (machine-local overrides)
+.claude/settings.local.json
 
 # debug
 npm-debug.log*

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+	"mcpServers": {
+		"playwright": {
+			"command": "npx",
+			"args": ["@playwright/mcp@latest", "--browser", "firefox"]
+		}
+	}
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,42 @@ provisioned in [lilbro-tf](https://github.com/jedwards1230/lilbro-tf) at
 `.github/workflows/ci.yml` runs lint, typecheck, build, and Playwright e2e on every
 PR (both jobs install and build independently). Both must be green before merging.
 
+## Visual Verification
+
+For CSS/layout/rendered-output changes, verify visually before a PR (skip for
+config/tooling-only changes):
+
+```bash
+bun install --frozen-lockfile
+# Run the Vite dev server (it renders the full UI — see note below).
+bun run dev -- --port 9875
+# Use Playwright (MCP): navigate to http://localhost:9875/ and screenshot the
+# homepage in both light and dark mode. Save under .playwright-mcp/ (gitignored)
+# so screenshots are never committed.
+```
+
+This site is a **static SPA** — `src/App.tsx` renders the entire homepage (name,
+role, email) with no data fetching or backend. The Vite dev server renders the
+full UI on its own, so **no seeded fixtures or mock data are required**. The
+only route is `/`.
+
+**Dark mode** is driven purely by `prefers-color-scheme` in `src/index.css`
+(there is no `data-theme` toggle). To screenshot dark mode via Playwright MCP,
+emulate the color scheme (`browser_resize`/`browser_run_code_unsafe` with the
+emulation API, or launch with the dark scheme) rather than setting an attribute.
+
+The Playwright MCP server is declared in `.mcp.json` (`--browser firefox`). On
+Claude Code on the web, `.claude/hooks/session-start.sh` installs the firefox
+browser binary (for the MCP server) and chromium (for the automated suite below)
+so `browser_navigate` and `test:e2e` both work without manual setup; locally,
+run `bunx playwright install firefox chromium` once.
+
+This interactive visual check is **separate from the automated `test:e2e`
+suite**: `bun run test:e2e` runs `tests/smoke.spec.ts` against `chromium` via
+`wrangler pages dev` on the built `dist/` (to exercise the production 404.html
+fallback), while visual verification drives the live Vite dev server in firefox
+for ad-hoc screenshots. They complement each other — neither replaces the other.
+
 ## Conventions
 
 - **Indentation**: tabs (see `.prettierrc` — `useTabs: true`, `tabWidth: 4`)


### PR DESCRIPTION
Applies the visual-verification pattern (from `my-wiki`) to this Vite + React SPA so a Claude Code (web) session can launch the app and screenshot it.

## Changes
- **`.mcp.json`** — Playwright MCP server pinned to `--browser firefox` for interactive screenshots.
- **`.claude/hooks/session-start.sh`** — remote-gated (`CLAUDE_CODE_REMOTE=true`), idempotent. Installs **firefox** (for the MCP server) **and chromium** (the browser the existing `test:e2e` suite uses, per `playwright.config.ts`) plus their OS deps, so both interactive screenshots and the automated suite work on web. `chmod +x`.
- **`.claude/settings.json`** — registers the SessionStart hook; minimal bun/Vite-scoped permissions. (Did not exist before.)
- **`.gitignore`** — ignore `.playwright-mcp/` (screenshot output) and `.claude/settings.local.json`.
- **`CLAUDE.md`** — new *Visual Verification* section: install → `bun run dev` → navigate + screenshot light/dark of `/` → save under `.playwright-mcp/`. Documents that this is separate from (and complementary to) the automated chromium `test:e2e` suite.

## Mock data: none needed
The site is a **fully static SPA** — `src/App.tsx` renders the entire homepage (name/role/email) with no data fetching or backend, and dark mode is pure `prefers-color-scheme`. The Vite dev server renders the complete UI on its own, so no seed/fixture script was added. This is documented in the new CLAUDE.md section rather than papered over with a pointless script.

## Browser reconciliation
The existing e2e (`playwright.config.ts`) pins the **chromium** project. The MCP server uses **firefox** to match the shared session-start hook convention. The hook installs both, so neither path breaks.

## Verification
Ran `bun install --frozen-lockfile` then `bun run dev -- --port 9875`; `curl -sf http://localhost:9875/` returned **HTTP 200** with the expected HTML (`<title>J. Edwards</title>`). Server then stopped. No Playwright `browser_*` tools were invoked (shared browser is contended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01FuM1ckNF3KqdPmJXGhBbpm