### PR TITLE
docs: add CONTRIBUTING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # personal-website
 
+@CONTRIBUTING.md
+
 Single-page landing site for [jedwards.cc](https://jedwards.cc) — pure SPA, no SSR.
 
 ## Stack
@@ -13,17 +15,11 @@ Single-page landing site for [jedwards.cc](https://jedwards.cc) — pure SPA, no
 
 ## Commands
 
-| Command                         | Description                                            |
-| ------------------------------- | ------------------------------------------------------ |
-| `bun install --frozen-lockfile` | Install deps                                           |
-| `bun run dev`                   | Vite dev server on http://localhost:3000               |
-| `bun run build`                 | `tsc -b` + Vite production build to `dist/`            |
-| `bun run preview`               | Serve built `dist/` on http://localhost:4173           |
-| `bun run lint`                  | ESLint (flat config)                                   |
-| `bun run typecheck`             | `tsc -b --noEmit`                                      |
-| `bun run format`                | Prettier (tabs, width 4)                               |
-| `bun run test:e2e`              | Playwright smoke tests                                 |
-| `bun run deploy`                | Build + manual deploy via `wrangler pages deploy dist` |
+| Command               | Description                                            |
+| --------------------- | ------------------------------------------------------ |
+| `bun run dev`         | Vite dev server on http://localhost:3000               |
+| `bun run preview`     | Serve built `dist/` on http://localhost:4173           |
+| `bun run deploy`      | Build + manual deploy via `wrangler pages deploy dist` |
 
 ## Layout
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing to personal-website
+
+Single-page landing site for [jedwards.cc](https://jedwards.cc) — pure SPA built with Vite, React 19, and TypeScript. All changes go through the workflow below.
+
+## Prerequisites
+
+- [Bun](https://bun.sh/) (latest) — used for installs, running scripts, and the dev server
+- [Node.js](https://nodejs.org/) >= 22 — required by Wrangler for the e2e job
+
+Install Playwright browsers once before running e2e tests:
+
+```bash
+bunx playwright install chromium
+```
+
+## Build, test & lint
+
+```bash
+bun install --frozen-lockfile
+
+# Lint and type-check (run before every commit)
+bun run lint
+bun run typecheck
+
+# Production build
+bun run build
+
+# Playwright e2e smoke tests (runs against the built dist/ via wrangler pages dev)
+bun run test:e2e
+
+# Format (Prettier — tabs, width 4)
+bun run format
+```
+
+CI runs `lint`, `typecheck`, and `build` in the `build` job, then `test:e2e` in a separate `e2e` job that needs `build` to succeed first.
+
+## Documentation
+
+Keep documentation current as part of the change, not as a follow-up — update the README and any affected docs in the same PR.
+
+## Before you open a PR
+
+- Make sure all CI checks pass locally first — run the formatter, linter, and tests.
+
+## Branching & commits
+
+- Branch off `main`; never commit directly to `main`.
+- Use [Conventional Commits](https://www.conventionalcommits.org/) prefixes (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`, …).
+- Sign your commits where possible (`git commit -S`).
+- Keep each PR focused; delete dead code rather than commenting it out.
+
+## Pull requests
+
+- Open the PR against `main`.
+- Every PR runs CI. Resolve **all** review threads before the PR is merged.
+- An automated code review runs on each PR; address and resolve its threads like any other review.
+- A PR can be merged once CI is green and all review threads are resolved.
+
+## Releases
+
+This repo is not a versioned artifact — there is no release step. Merging to `main` deploys automatically via Cloudflare Pages.

--- a/README.md
+++ b/README.md
@@ -11,24 +11,24 @@ Single-page landing site for [jedwards.cc](https://jedwards.cc).
 
 ## Scripts
 
-| Command             | What it does                                     |
-| ------------------- | ------------------------------------------------ |
-| `bun run dev`       | Vite dev server on http://localhost:3000         |
-| `bun run build`     | Type-check + production build to `dist/`         |
-| `bun run preview`   | Serve the built `dist/` on http://localhost:4173 |
-| `bun run lint`      | ESLint (flat config)                             |
-| `bun run typecheck` | `tsc -b --noEmit`                                |
-| `bun run format`    | Prettier (tabs, width 4)                         |
-| `bun run test:e2e`  | Playwright smoke tests                           |
-| `bun run deploy`    | Build + `wrangler pages deploy dist`             |
+| Command           | What it does                                     |
+| ----------------- | ------------------------------------------------ |
+| `bun run dev`     | Vite dev server on http://localhost:3000         |
+| `bun run build`   | Type-check + production build to `dist/`         |
+| `bun run preview` | Serve the built `dist/` on http://localhost:4173 |
+| `bun run deploy`  | Build + `wrangler pages deploy dist`             |
 
 ## Deploy
 
 Auto-deploys on push to `main` via Cloudflare Pages. The Pages project is provisioned
-via Terraform — see [CLAUDE.md](./CLAUDE.md) for build image requirements and the
-Terraform module location.
+via Terraform at `modules/cloudflare/main.tf` in
+[lilbro-tf](https://github.com/jedwards1230/lilbro-tf).
 
 The static `public/404.html` is served automatically on unmatched routes.
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for build, test, lint, and PR workflow.
 
 ## License
 


### PR DESCRIPTION
Part of the org-wide CONTRIBUTING.md rollout (13 repos already done). Applies the three-file split: CONTRIBUTING.md as single canonical home for build/test/lint and PR workflow, `@CONTRIBUTING.md` import in CLAUDE.md with its duplicated commands block removed, and a short Contributing section added to README with contributor-only scripts trimmed.

Noted drift: none.

https://claude.ai/code/session_01UbFYMkLjjvLsU1DjHowC2E