### PR TITLE
ci: pin actions/checkout to v7.0.0 by SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -35,7 +35,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@v5
         with:
           # Wrangler requires Node >= 22; setup-bun's bundled node is 20.


### PR DESCRIPTION
## Summary

- Pins both `actions/checkout` references in `.github/workflows/ci.yml` from `@v6` to the exact v7.0.0 commit SHA (`9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`) for supply-chain hardening.
- No other actions or workflow logic were changed.

## Files changed

- `.github/workflows/ci.yml` — 2 occurrences updated (build job and e2e job)

https://claude.ai/code/session_01UbFYMkLjjvLsU1DjHowC2E