### PR TITLE
chore(dependabot): add version-update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# .github/dependabot.yml — Dependabot version updates (per repo-standards Wave 3)
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels: ["dependency", "chore"]
+    commit-message:
+      prefix: "deps(actions)"
+    groups:
+      actions:
+        patterns: ["*"]
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels: ["dependency", "chore"]
+    commit-message:
+      prefix: "deps(npm)"
+    groups:
+      npm:
+        patterns: ["*"]


### PR DESCRIPTION
Adds Dependabot version updates (2 grouped weekly entries, limit 5, deps(<eco>) commit prefix) — repo-standards Wave 3.