### PR TITLE
chore(claude): enable screenshotter plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -43,5 +43,16 @@
 				]
 			}
 		]
+	},
+	"enabledPlugins": {
+		"screenshotter@jedwards1230-plugins": true
+	},
+	"extraKnownMarketplaces": {
+		"jedwards1230-plugins": {
+			"source": {
+				"source": "github",
+				"repo": "jedwards1230/claude-plugins"
+			}
+		}
 	}
 }


### PR DESCRIPTION
## What

Enables the **`screenshotter`** plugin (`screenshotter@jedwards1230-plugins`) for this repo — a generic, agent-only UI screenshotter that captures, self-verifies, and returns screenshots of any app, UI, or web page, keeping the noisy capture loop out of the parent conversation.

## Why here

This repo already has a Playwright MCP server in its `.mcp.json`, which the agent uses for web capture. The plugin is **agent-only** (it bundles no MCP server), so this change is **purely additive**:

- Adds `screenshotter@jedwards1230-plugins` to `enabledPlugins` (+ registers the `jedwards1230-plugins` marketplace where it wasn't already known).
- **Nothing removed** — the existing `.mcp.json` Playwright config is untouched, and its `mcp__playwright__*` tool names are unchanged. The agent inherits them.

## Notes

Native (non-browser) capture needs no setup; web capture uses the existing Playwright server. If Playwright tools are ever absent, the agent reports the exact setup and stops rather than spinning.

https://claude.ai/code/session_01PbVnUh8iV2uSoytq9Lvmp7
