### PR TITLE
chore: repo-standards remediation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
       - run: bun install --frozen-lockfile
       - run: bun run lint
       - run: bun run typecheck
       - run: bun run build
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: github.event_name == 'pull_request'
         with:
           name: dist
@@ -36,18 +36,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           # Wrangler requires Node >= 22; setup-bun's bundled node is 20.
           node-version: "22"
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
       - run: bun install --frozen-lockfile
       - run: bunx playwright install --with-deps chromium
       - run: bun run build
       - run: bun run test:e2e
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: playwright-report


### PR DESCRIPTION
## Summary
- Finish SHA-pinning GitHub Actions in `.github/workflows/ci.yml`: `oven-sh/setup-bun@v2`, `actions/setup-node@v6`, `actions/upload-artifact@v7` are now pinned to full commit SHAs (`# vN` comment retained). `actions/checkout` was already pinned.
- `claude-pr-review.yml`'s same-org reusable-workflow calls (`jedwards1230/release-workflows/...@v1`) are intentionally left on the moving `@v1` tag per this portfolio's reusable-workflow convention — out of scope for this pass.

Post-merge: set `sha_pinning_required=true`.

## Test plan
- [x] Diff reviewed — pins match resolved SHAs for the exact tags previously referenced
- [ ] CI runs green on this PR (build + e2e jobs use the pinned actions)